### PR TITLE
refactor: change print method

### DIFF
--- a/lib/clio.js
+++ b/lib/clio.js
@@ -140,7 +140,7 @@ var _pre = function(c, asStr) {
     c = '\x1B[' + (c || "");
 
     if(!asStr) {
-        util.print(c);
+        console.log(c);
     }
 
     return c;
@@ -244,7 +244,7 @@ var detokenize = function(str) {
 //
 var write = function(str) {
 
-    util.print(prepare(str));
+    console.log(prepare(str));
 };
 
 //	##prepare
@@ -613,7 +613,7 @@ var clio = {
 var v;
 var rf = function(meth, c) {
 	return function() {
-		util.print(meth(c));
+		console.log(meth(c));
 	}
 }
 

--- a/lib/clio.js
+++ b/lib/clio.js
@@ -1,6 +1,5 @@
 module.exports = function(options) {
 
-var util	= require('util');
 var fs      = require('fs');
 var tty     = require('tty');
 


### PR DESCRIPTION
Due to deprecation, util.print is no longer used. A good alternative is console.log.